### PR TITLE
LiSP: Section 1.6 - function execution environment

### DIFF
--- a/clojure/src/ch01_evaluator.clj
+++ b/clojure/src/ch01_evaluator.clj
@@ -17,22 +17,15 @@
 ;; they define atom as anything that's not a "pair" (cons cell)
 ;; - we use `list?` for Clojure which should be good enough
 (def atom? (complement list?))
-(atom? 1)
-;; => true
-(atom? "ahoj")
-;; => true
-(atom? \c)
-;; => true
-(atom? '(1 2 3))
-;; => false
-;; TODO: notice that other composite data structures like vectors are considered atoms!
-(atom? [1 2 3])
-;; => true
-(atom? {1 2 3 4})
-;; => true
+(assert (true? (atom? 1)))
+(assert (true? (atom? "ahoj")))
+(assert (true? (atom? \c)))
+(assert (false? (atom? '(1 2 3))))
+;; TODO: notice that vectors are considered atoms!
+(assert (true? (atom? [1 2 3])))
+(assert (true? (atom? {1 2 10 20})))
 ;; while keywords are not really supported by our language's evaluate function we consider them atomic
-(atom? :atomic)
-;; => true
+(assert (true? (atom? :atomic)))
 
 (defn evaluate [exp env]
   (if (atom? exp)
@@ -70,12 +63,9 @@
     ;; we use `first` instead of `car`
     (case (first exp))))
 
-(evaluate 1 {})
-;; => 1
-(evaluate "ahoj" {})
-;; => "ahoj"
-(evaluate [1 2 3] {})
-;; => [1 2 3]
+(assert (= 1 (evaluate 1 {})))
+(assert (= "ahoj" (evaluate "ahoj" {})))
+(assert (= [1 2 3] (evaluate [1 2 3] {})))
 
 ;;; 1.4 Evaluating forms (p. 6 - 12)
 ;;; Discusses "special forms" like quote, if, set!, lambda, begin
@@ -199,9 +189,8 @@
                                                :env env
                                                :value value})))
 
-(evaluate '(set! x 1) {})
-;; => {x 1}
-
+(assert (= '{x 1}
+           (evaluate '(set! x 1) {})))
 
 ;; An empty environment.
 ;; Note: in the book they use the name `env.init` but that has a special meaning in Clojure.
@@ -264,9 +253,8 @@
 ;; 1. Unhandled clojure.lang.ExceptionInfo
 ;; No such binding
 ;; {:expression println, :rest-args nil}
-(lookup 'a '{a 10 b 20})
-;; => 10
-
+(assert (= 10
+           (lookup 'a '{a 10 b 20})))
 
 ;; p.16: evaluating a function comes down to evaluating its body
 ;; in an environment where its variables are bound to the values
@@ -282,10 +270,10 @@
   (fn [values] ; does `values` really do what we want?? (spoiler: no!)
     (eprogn body (extend env-init variables values))))
 ;; try it!
-(evaluate '((lambda (a b) a)
-             1 2)
-           {})
-;; => 1
+(assert (= 1
+           (evaluate '((lambda (a b) a)
+                       1 2)
+                     {})))
 
 ;; Let's try again with `& values`
 ;; notice that `env` is unused which leads to the problem described below.

--- a/clojure/test/ch01_evaluator_test.clj
+++ b/clojure/test/ch01_evaluator_test.clj
@@ -18,6 +18,7 @@
 
 (deftest evaluate-test
   (testing "evaluate a sequence"
-    (is (= [1 2 3 4 5 6 7 8 9 10] ; just check that the last value is returned - it's harder to check the side effects
-           (evaluate '(begin (inc 1) (println "ahoj") (map inc (range 10)))
-                     {})))))
+    (is (= '(1 2 3) ; just check that the last value is returned - it's harder to check the "side effects" (that is `(+ 1 2)`)
+           ;; functions `+` and `list` are the only ones that are defined as of 1.6 (p. 19)
+           (evaluate '(begin (+ 1 2) (list 1 2 3) )
+                     evaluator/env-global)))))


### PR DESCRIPTION
Just starting with the section 1.6
Implementing `make-function` and trying it on a simple expression.

From the book: 
> Applying a function comes down to evaluating its body in an environment where its variables are bound to values that they have assumed during the application.

## Description of the changes - somewhat obsolete

Some of this is still relevant but many examples might be wrong!
The problem was that I extended the environment (like adding  a `car` function) incorrectly.
It helped me a lot to look at Chouser's examples: https://github.com/Chouser/lisp-in-small-pieces-clj/blob/main/src/us/chouser/LISP/ch1a.clj#L216-L220

Then, I could get rid of `& values` inside `make-function`, `apply f args` inside `invoke`,
and also adding current-env as the last element of `args` manually and then extracting it again.

### `lookup` function "fix"

For `lookup` - we made it too smart by using `resolve` and `var-get`.
We should start with an empty environment and don't allow the usual Clojure functions like `println` to be used.
Going back to the minimalistic implementation of lookup (p. 13)

```
(defn lookup [id env]
  (if-let [[k v] (find env id)]
    v
    (wrong "No such binding" id)))
#_(lookup 'println {})
;; 1. Unhandled clojure.lang.ExceptionInfo
;; No such binding
;; {:expression println, :rest-args nil}
(lookup 'a '{a 10 b 20})
;; => 10
```

### Minimal environment 

Note that the straightforward implementation had problems: 
```
(defn make-function [variables body env]
  (fn [values] ; TODO: does `values` really do what we want??
    (eprogn body (extend env-init variables values))))
((evaluate '(lambda (a b) a)
           {})
 1 2)
;; Wrong number of args (2) passed to: ch01-evaluator/make-function/fn--13185
```
So we have to use `& values` in the fn arg vector: 
```
(defn make-function [variables body env]
  (fn [& values]
    (eprogn body (extend env-init variables values))))
((evaluate '(lambda (a b) a)
           {})
 1 2)
;; => 1

```

### Patched Environment

Improves upon the minimal environment by using `env-global` to make common functions available - those common functions will be added only in section 1.7 (p. 25)
but to make examples working we add functions like `+`, `car`, and `list` to it:
```
(def env-global (assoc env-global
                       'car first
                       '+ +
                       'list list))
```

This now works: 
```
(evaluate '((lambda (a) (car a))
            '(30 20 10))
          env-global)
;; => 30
```

But the problem is that nested lambdas don't work - the inner function doesn't seem bindings established by the outer function: 
```
(evaluate '((lambda (a)
                    ;; `a` isn't present in the environment visible to this inner lambda
                    ((lambda (b) (list a b))
                     (+ 2 a)))
            1)
          env-global)
;; 1. Unhandled clojure.lang.ExceptionInfo
;; No such binding
;; {:expression a, :rest-args nil}
```

### iii) Improving the patch

To see see the outer variables in the inner functions,
our solution is to just pass the current environment
to `invoke` which then passes it to the functions being invoked.
In both cases, the env is passed as the last argument.
We'll redefine `evaluate`, `make-function`, and `invoke`.
To avoid confusion with previous definitions we'll use new names with `d-` prefix
(this is also used because the solution won't be the final one that we'll use)