### PR TITLE
Wrap-up section 1.7 (Global environment)

### DIFF
--- a/clojure/src/ch01_evaluator.clj
+++ b/clojure/src/ch01_evaluator.clj
@@ -671,7 +671,7 @@
   )
 
 
-;; p18 - we now define  a few useful constants
+;; p28 - we now define  a few useful constants
 (defn define-constants []
   (definitial t true)
   (definitial f false)
@@ -735,3 +735,85 @@ env-global
            env-global)
 ;; => 1
 
+
+;; now define some random variables that Lispers typically use :) (p.27)
+(defn setup-vars []
+  (definitial foo)
+  (definitial bar)
+  (definitial fib)
+  (definitial fact))
+(setup-vars)
+;; => {t true,
+;;     f false,
+;;     nil nil,
+;;     foo :ch01-evaluator/void,
+;;     bar :ch01-evaluator/void,
+;;     fib :ch01-evaluator/void,
+;;     fact :ch01-evaluator/void}env-global
+
+
+;; Finally, define a few useful library functions
+(defn stdlib []
+  (defprimitive cons cons 2)
+  (defprimitive car first 1)
+  ;; set-cdr! function is more complicated because it actually mutates the list
+  ;; consider this example from mit-scheme implementation:
+  ;;
+  ;;     (define x '(1 2 3))
+  ;;
+  ;;     x
+  ;;     ;Value: (1 2 3)
+
+  ;;     (set-cdr! x '(20 30))
+  ;;     ;Unspecified return value
+  ;;
+  ;;     x
+  ;;     ;Value: (1 20 30)
+  ;; For now, we simply ignore the mutability aspect and return a modified copy
+  (defprimitive set-cdr! (fn [xs new-rst] (cons (first xs) new-rst)) 2)
+  (defprimitive + + 2)
+  (defprimitive eq? = 2)
+  (defprimitive < < 2))
+(stdlib)
+;; => {nil nil,
+;;     t true,
+;;     < #function[ch01-evaluator/stdlib/fn--21746/fn--21747],
+;;     cons #function[ch01-evaluator/stdlib/fn--21726/fn--21727],
+;;     fib :ch01-evaluator/void,
+;;     set-cdr! #function[ch01-evaluator/stdlib/fn--21734/fn--21735],
+;;     car #function[ch01-evaluator/stdlib/fn--21730/fn--21731],
+;;     bar :ch01-evaluator/void,
+;;     fact :ch01-evaluator/void,
+;;     + #function[ch01-evaluator/stdlib/fn--21738/fn--21739],
+;;     eq? #function[ch01-evaluator/stdlib/fn--21742/fn--21743],
+;;     foo :ch01-evaluator/void,
+;;     f false}
+
+(comment
+  ;; with empty env it doesn't work:
+  (evaluate '(cons 1 [2 3]) {})
+  ;; No such binding
+  ;; {:expression cons, :args nil}
+  ;; but it's in the global env
+  (evaluate '(cons 1 [2 3]) env-global)
+  ;; => (1 2 3)
+
+  (evaluate '(car [1 2 3]) env-global)
+  ;; => 1
+
+
+  (evaluate '(set-cdr! [1 2 3] [20 30]) env-global)
+  ;; => (1 20 30)
+
+  (evaluate '(+ 10 100) env-global)
+  ;; => 110
+
+  (evaluate '(eq? '(1 2) [1 2 3]) env-global)
+  ;; => false
+  (evaluate '(eq? '(1 2 3) [1 2 3]) env-global)
+  ;; => true
+
+  (evaluate '(< 2 3) env-global)
+  ;; => true
+
+  .)


### PR DESCRIPTION
Define booleans `t` (true) and `f` (false) and lock the bindings in the interpreter (`evaluate`) so they can't be shadowed.

Define some useful primitives ("standard library") like `cons`, `car`, etc. via macro `defprimitive` that adds definitions to the global environment