### PR TITLE
LiSP ch2: implement f-evaluate and friends (p. 33-34).

### DIFF
--- a/clojure/src/ch01_evaluator_final.clj
+++ b/clojure/src/ch01_evaluator_final.clj
@@ -222,6 +222,7 @@
   ;; For now, we simply ignore the mutability aspect and return a modified copy
   (defprimitive set-cdr! (fn [xs new-rst] (cons (first xs) new-rst)) 2)
   (defprimitive + + 2)
+  (defprimitive * * 2)
   (defprimitive eq? = 2)
   (defprimitive < < 2)
   (defprimitive list (fn [& values] (or values ())) {:min-arity 0})

--- a/clojure/src/ch01_evaluator_final.clj
+++ b/clojure/src/ch01_evaluator_final.clj
@@ -44,11 +44,10 @@
     ;; here we could also return `nil` or other value - see discussion on p.10
     ()))
 
-(defn lookup [exp env]
-  (if-let [[_k v] (find env exp)]
+(defn lookup [id env]
+  (if-let [[_k v] (find env id)]
     v
-    ;; resolve symbols to the object it points to
-    (some-> exp resolve var-get)))
+    (wrong "No such binding" id)))
 
 ;; ... we also need evlis which is only defined in section 1.4.6 (p.12)
 (defn evlis [exps env]

--- a/clojure/src/ch01_evaluator_final.clj
+++ b/clojure/src/ch01_evaluator_final.clj
@@ -250,6 +250,7 @@
 (assert (= 1 (evaluate '(car [1 2 3]) env-global)))
 (assert (= '(1 20 30) (evaluate '(set-cdr! [1 2 3] [20 30]) env-global)))
 (assert (= 110 (evaluate '(+ 10 100) env-global)))
+(assert (= 1000 (evaluate '(* 10 100) env-global)))
 (assert (false? (evaluate '(eq? '(1 2) [1 2 3]) env-global)))
 (assert (true? (evaluate '(eq? '(1 2 3) [1 2 3]) env-global)))
 (assert (true? (evaluate '(< 2 3) env-global)))

--- a/clojure/src/ch01_exercises.clj
+++ b/clojure/src/ch01_exercises.clj
@@ -15,6 +15,9 @@
 ;; We probably need to redefine make-function to make it work;
 ;; and similarly to `ch01-evaluator.d-evaluate`,
 ;; you also need to redefine a bunch of other functions
+;; Note: in the book, they simply did it by injecting trace points
+;; directly into `evaluate` itself => no need to modify other functions.
+
 (declare trace-evaluate)
 
 (defn trace-eprogn

--- a/clojure/src/ch02_lisp2.clj
+++ b/clojure/src/ch02_lisp2.clj
@@ -69,14 +69,14 @@
   (fn [values]
     ;; notice that `fenv` isn't extended since it's only for functions,
     ;; not for the variables inside the body of the function
-    (f-eprogn body (extend env variables values) fenv)))
+    (f-eprogn body (e/extend env variables values) fenv)))
 
 ;; ... and finally we can implement `evaluate-application`
 (defn evaluate-application [f args env fenv]
   (cond
     ;; function symbol -> invoke it right away
     (symbol? f)
-    (e/invoke f args)
+    (e/invoke (e/lookup f fenv) args) ; notice we lookup the function symbol in `fenv`
 
     ;; lambda forms are also supported - notice they don't produce a function object (via `f-make-function`)
     ;; but instead are evaluated directly
@@ -84,23 +84,99 @@
     ;; this is the same thing as body of the function produced by `f-make-function`
     ;; - using `(nnext f)` to skip lambda symbol and its arglist
     ;; - using `(second f)` to get the arg list, that is the list of symbols that should be bound to their values (`args`)
-    (f-eprogn (nnext f) (extend env (second f) args) fenv)
+    (f-eprogn (nnext f) (e/extend env (second f) args) fenv)
 
     :else (e/wrong "Incorrect functional term" f {:f f :args args :fenv fenv :env env})))
+
+;; we define our own + and * functions to be able to pass them
+;; inside `fenv` - normally, they are defined  in `e/env-global`.
+;; the reason why we cannot simply use clojure.core functions
+;; is that we need to call `apply` since the arguments are wrapped within a list.
+(defn my+ [args] (apply + args))
+(defn my* [args] (apply * args))
+(assert (= 7
+           (f-evaluate '(+ 3 4) {} {'+ my+})))
 
 ;; now compare `evaluate` and `f-evaluate`
 ;; - without special support, with `f-evaluate` you shouldn't be able to use more complicated forms in a function position
 ;; (this example using `(if condition + *)` comes from p. 37)
-(assert (= 7 (e/evaluate '((if condition + *) 3 4) (assoc e/env-global 'condition true))))
-(assert (= 12 (e/evaluate '((if condition + *) 3 4) (assoc e/env-global 'condition false))))
+(assert (= 7 (e/evaluate '((if condition + *) 3 4)
+                         {'condition true '+ my+ '* my*})))
+(assert (= 12 (e/evaluate '((if condition + *) 3 4)
+                          {'condition false '+ my+ '* my*})))
 
 ;; f-evaluate doesn't know how to evaluate non-function forms in the function position
 (try
   (f-evaluate '((if condition + *) 3 4)
-              (assoc e/env-global 'condition true)
-              {})
+              {'condition true}
+              {'+ my+ '* my*})
   (assert false "f-evaluate should fail when called with a non-function form in the function position")
   (catch Exception e
     (assert (= "Incorrect functional term" (ex-message e)))))
 
+
+;; Now, the other difference between `f-evaluate` and `e/evaluate` is that
+;; `f-evaluate` can invoke lambda forms directly without creating a function object.
+;; Consider this example and enable tracing for `f-evaluate` and `e/evaluate`:
+
+(f-evaluate '((lambda (x) (* x x)) 3)
+            {'x 2}
+            {'* my*})
+;; TRACE t11240: (ch02-lisp2/f-evaluate ((lambda (x) (* x x)) 3) {x 2} {* #function[ch02-lisp2/my*]})
+;; TRACE t11241: | (ch02-lisp2/f-evaluate 3 {x 2} {* #function[ch02-lisp2/my*]})
+;; TRACE t11241: | => 3
+;; TRACE t11242: | (ch02-lisp2/f-evaluate (* x x) {x 3} {* #function[ch02-lisp2/my*]})
+;; TRACE t11243: | | (ch02-lisp2/f-evaluate x {x 3} {* #function[ch02-lisp2/my*]})
+;; TRACE t11243: | | => 3
+;; TRACE t11244: | | (ch02-lisp2/f-evaluate x {x 3} {* #function[ch02-lisp2/my*]})
+;; TRACE t11244: | | => 3
+;; TRACE t11242: | => 9
+;; TRACE t11240: => 9
+
+(e/evaluate '((lambda (x) (* x x)) 3)
+            {'x 2 '* my*})
+;; TRACE t11247: (ch01-evaluator-final/evaluate ((lambda (x) (* x x)) 3) {x 2, * #function[ch02-lisp2/my*]})
+;; TRACE t11248: | (ch01-evaluator-final/evaluate (lambda (x) (* x x)) {x 2, * #function[ch02-lisp2/my*]})
+;; TRACE t11248: | => #function[ch01-evaluator-final/make-function/fn--10567]
+;; TRACE t11249: | (ch01-evaluator-final/evaluate 3 {x 2, * #function[ch02-lisp2/my*]})
+;; TRACE t11249: | => 3
+;; TRACE t11250: | (ch01-evaluator-final/evaluate (* x x) {x 3, * #function[ch02-lisp2/my*]})
+;; TRACE t11251: | | (ch01-evaluator-final/evaluate * {x 3, * #function[ch02-lisp2/my*]})
+;; TRACE t11251: | | => #function[ch02-lisp2/my*]
+;; TRACE t11252: | | (ch01-evaluator-final/evaluate x {x 3, * #function[ch02-lisp2/my*]})
+;; TRACE t11252: | | => 3
+;; TRACE t11253: | | (ch01-evaluator-final/evaluate x {x 3, * #function[ch02-lisp2/my*]})
+;; TRACE t11253: | | => 3
+;; TRACE t11250: | => 9
+;; TRACE t11247: => 9
+
+;; We can see that `e/evaluate` has more work to do because it creates a function object,
+;; that is `#function[ch01-evaluator-final/make-function/fn--10567]` in the output above
+
+
+;; Finally, when would `f-evaluate` still call `f-make-function`
+;; instead of executing the lambda form right away?
+;; One example is when we don't apply the function immediately
+(assert (fn?
+         (f-evaluate '(lambda (x) (* x x))
+                     {'x 2}
+                     {'* my*})))
+;; TRACE t11284: (ch02-lisp2/f-evaluate (lambda (x) (* x x)) {x 2} {* #function[ch02-lisp2/my*]})
+;; TRACE t11284: => #function[ch02-lisp2/f-make-function/fn--11194]
+
+;; that returns a function object to the host environment.
+;; we can apply it in Clojure though
+(assert (= 100
+           ((f-evaluate '(lambda (x) (* x x))
+                        {'x 2}
+                        {'* my*})
+            [10])))
+;; TRACE t11287: (ch02-lisp2/f-evaluate (lambda (x) (* x x)) {x 2} {* #function[ch02-lisp2/my*]})
+;; TRACE t11287: => #function[ch02-lisp2/f-make-function/fn--11194]
+;; TRACE t11288: (ch02-lisp2/f-evaluate (* x x) {x 10} {* #function[ch02-lisp2/my*]})
+;; TRACE t11289: | (ch02-lisp2/f-evaluate x {x 10} {* #function[ch02-lisp2/my*]})
+;; TRACE t11289: | => 10
+;; TRACE t11290: | (ch02-lisp2/f-evaluate x {x 10} {* #function[ch02-lisp2/my*]})
+;; TRACE t11290: | => 10
+;; TRACE t11288: => 100
 

--- a/clojure/src/ch02_lisp2.clj
+++ b/clojure/src/ch02_lisp2.clj
@@ -1,0 +1,106 @@
+(ns ch02-lisp2
+  "Chapter 2 exercises related to Lisp-2 style lisps, like Common Lisp.
+  It presents an alternative version of evaluate (`f-evaluate`)
+  that has a special function `evaluate-application` for evaluating function forms.
+  There are also `f-make-function`, `f-evlis` and `f-eprogn`.
+
+  Notice, that there's also a separate environment, `fenv`, dedicated functions;
+  it doesn't contain normal variables."
+  (:require [ch01-evaluator-final :as e]))
+
+
+;;; In Lisp-2, we will restrict the first element of every form to be a symbol.
+;;; That simplifies  the evaluation for the term in function position a lot.
+;;; We no longer needs all the complexity of `evaluate`.
+
+;; Let's copy `evaluate` but modify the function invocation at the end
+;; - call `evaluate-application` instead of using `invoke` directly
+(declare evaluate-application f-eprogn f-evlis f-make-function)
+(defn f-evaluate [exp env fenv]
+  (if (e/atom? exp)
+    (cond
+      ;; lock immutability of t and f in the interpreter
+      (= 't exp) true
+      (= 'f exp) false
+      (symbol? exp) (e/lookup exp env)
+      ;; Notice that `keyword?` isn't here because keywords are Clojure's thing
+      ;; and aren't present in the Lisp we are trying to implement
+      ((some-fn number? string? char? boolean? vector?) exp) exp
+      :else (e/wrong "Cannot evaluate - unknown atomic expression?" exp))
+
+    ;; we use `first` instead of `car`
+    (case (first exp)
+      quote (second exp)
+      ;; (p.8) we gloss over the fact that in `(if pred)` we use boolean semantics
+      ;; of the implementation language (Clojure - which means `nil` will be falsy);
+      ;; more precisely, we should write `(if-not (= the-false-value (evaluate (second exp) env)))
+      if (if (f-evaluate (second exp) env fenv)
+           (f-evaluate (nth exp 2) env fenv)
+           (f-evaluate (nth exp 3) env fenv))
+      begin (f-eprogn (rest exp) env fenv)
+      set! (e/update! (second exp) env (f-evaluate (nth exp 2) env fenv))
+      lambda (f-make-function (second exp) (nnext exp) env fenv)
+      ;; CHANGE: call `evaluate-application` instead of `invoke`
+      (evaluate-application (first exp)
+                            (f-evlis (rest exp) env fenv)
+                            env
+                            fenv))))
+
+;; ... we need to re-define the helper functions like f-eprogn and f-evlis
+;; to make sure their propagate the function environment `fenv`
+(defn f-evlis [exps env fenv]
+  (if (list? exps)
+    (map #(f-evaluate % env fenv) exps)
+    ()))
+
+(defn f-eprogn
+  "Evaluates sequence of expressions in given environment."
+  [exps env fenv]
+  (if (list? exps)
+    (let [[fst & rst] exps
+          fst-val (f-evaluate fst env fenv)]
+      (if (list? rst)
+        (f-eprogn rst env fenv) 
+        fst-val))
+    ()))
+
+;; ... now we redefine `make-function` to leverage `fenv`
+(defn f-make-function [variables body env fenv]
+  (fn [values]
+    ;; notice that `fenv` isn't extended since it's only for functions,
+    ;; not for the variables inside the body of the function
+    (f-eprogn body (extend env variables values) fenv)))
+
+;; ... and finally we can implement `evaluate-application`
+(defn evaluate-application [f args env fenv]
+  (cond
+    ;; function symbol -> invoke it right away
+    (symbol? f)
+    (e/invoke f args)
+
+    ;; lambda forms are also supported - notice they don't produce a function object (via `f-make-function`)
+    ;; but instead are evaluated directly
+    (and (list? f) (= 'lambda (first f)))
+    ;; this is the same thing as body of the function produced by `f-make-function`
+    ;; - using `(nnext f)` to skip lambda symbol and its arglist
+    ;; - using `(second f)` to get the arg list, that is the list of symbols that should be bound to their values (`args`)
+    (f-eprogn (nnext f) (extend env (second f) args) fenv)
+
+    :else (e/wrong "Incorrect functional term" f {:f f :args args :fenv fenv :env env})))
+
+;; now compare `evaluate` and `f-evaluate`
+;; - without special support, with `f-evaluate` you shouldn't be able to use more complicated forms in a function position
+;; (this example using `(if condition + *)` comes from p. 37)
+(assert (= 7 (e/evaluate '((if condition + *) 3 4) (assoc e/env-global 'condition true))))
+(assert (= 12 (e/evaluate '((if condition + *) 3 4) (assoc e/env-global 'condition false))))
+
+;; f-evaluate doesn't know how to evaluate non-function forms in the function position
+(try
+  (f-evaluate '((if condition + *) 3 4)
+              (assoc e/env-global 'condition true)
+              {})
+  (assert false "f-evaluate should fail when called with a non-function form in the function position")
+  (catch Exception e
+    (assert (= "Incorrect functional term" (ex-message e)))))
+
+


### PR DESCRIPTION
Also demonstrate the difference between f-evaluate and evaluate.


## Differences

### f-evaluate doesn't know how to evaluate non-functional forms in the function position

```
;; `evaluate`  works fine
(assert (= 12 (e/evaluate '((if condition + *) 3 4) (assoc e/env-global 'condition false))))

;; but f-evaluate doesn't know how to evaluate non-function forms in the function position
(try
  (f-evaluate '((if condition + *) 3 4)
              (assoc e/env-global 'condition true)
              {})
  (assert false "f-evaluate should fail when called with a non-function form in the function position")
  (catch Exception e
    (assert (= "Incorrect functional term" (ex-message e)))))
```

### f-evaluate doesn't produce function objects when the lambda form is called immediately

```

(f-evaluate '((lambda (x) (* x x)) 3)
            {'x 2}
            {'* my*})
;; TRACE t11240: (ch02-lisp2/f-evaluate ((lambda (x) (* x x)) 3) {x 2} {* #function[ch02-lisp2/my*]})
;; TRACE t11241: | (ch02-lisp2/f-evaluate 3 {x 2} {* #function[ch02-lisp2/my*]})
;; TRACE t11241: | => 3
;; TRACE t11242: | (ch02-lisp2/f-evaluate (* x x) {x 3} {* #function[ch02-lisp2/my*]})
;; TRACE t11243: | | (ch02-lisp2/f-evaluate x {x 3} {* #function[ch02-lisp2/my*]})
;; TRACE t11243: | | => 3
;; TRACE t11244: | | (ch02-lisp2/f-evaluate x {x 3} {* #function[ch02-lisp2/my*]})
;; TRACE t11244: | | => 3
;; TRACE t11242: | => 9
;; TRACE t11240: => 9

(e/evaluate '((lambda (x) (* x x)) 3)
            {'x 2 '* my*})
;; TRACE t11247: (ch01-evaluator-final/evaluate ((lambda (x) (* x x)) 3) {x 2, * #function[ch02-lisp2/my*]})
;; TRACE t11248: | (ch01-evaluator-final/evaluate (lambda (x) (* x x)) {x 2, * #function[ch02-lisp2/my*]})
;; TRACE t11248: | => #function[ch01-evaluator-final/make-function/fn--10567]
;; TRACE t11249: | (ch01-evaluator-final/evaluate 3 {x 2, * #function[ch02-lisp2/my*]})
;; TRACE t11249: | => 3
;; TRACE t11250: | (ch01-evaluator-final/evaluate (* x x) {x 3, * #function[ch02-lisp2/my*]})
;; TRACE t11251: | | (ch01-evaluator-final/evaluate * {x 3, * #function[ch02-lisp2/my*]})
;; TRACE t11251: | | => #function[ch02-lisp2/my*]
;; TRACE t11252: | | (ch01-evaluator-final/evaluate x {x 3, * #function[ch02-lisp2/my*]})
;; TRACE t11252: | | => 3
;; TRACE t11253: | | (ch01-evaluator-final/evaluate x {x 3, * #function[ch02-lisp2/my*]})
;; TRACE t11253: | | => 3
;; TRACE t11250: | => 9
;; TRACE t11247: => 9

;; We can see that `e/evaluate` has more work to do because it creates a function object,
;; that is `#function[ch01-evaluator-final/make-function/fn--10567]` in the output above
```

### but f-evaluate still produces a function object if the lambda isn't called immediately

```
(assert (fn?
         (f-evaluate '(lambda (x) (* x x))
                     {'x 2}
                     {'* my*})))
;; TRACE t11284: (ch02-lisp2/f-evaluate (lambda (x) (* x x)) {x 2} {* #function[ch02-lisp2/my*]})
;; TRACE t11284: => #function[ch02-lisp2/f-make-function/fn--11194]
```