### PR TITLE
Lisp ch2: Section 2.4 - f-lookup and labels

### DIFF
--- a/clojure/src/ch01_evaluator_final.clj
+++ b/clojure/src/ch01_evaluator_final.clj
@@ -59,7 +59,7 @@
 (defn invoke [f args]
   (if (fn? f)
     (f args)
-    (wrong "Not a function" f args)))
+    (wrong "Not a function" f {:args args})))
 
 (defn update! [id env value]
   (if (map? env)

--- a/clojure/src/ch01_evaluator_final.clj
+++ b/clojure/src/ch01_evaluator_final.clj
@@ -2,7 +2,8 @@
   "Chapter 1: Basic evaluator - final version.
   This is similar to `ch01-evaluator` but skips intermediate steps and experiments.
   As such it provides a clearer picture of the current state of the code,
-  but it lacks some explanations.")
+  but it lacks some explanations."
+  (:refer-clojure :exclude [extend]))
 
 
 ;;; 1.3 (p.4): start building the implementation

--- a/clojure/src/ch02_lisp2.clj
+++ b/clojure/src/ch02_lisp2.clj
@@ -469,15 +469,18 @@
 
 ;; But if we flip the function definitions (quad is now first and it uses square defined later)
 ;; it's broken again!
-;; TODO: does this work with the implementation from the book?
+;; Note: this works with the implementation from the book
+;; because they are mutating the mapping in the env
+;; With immutable environment, it's gonna be harder => let's deal with this in section 2.6 (Recursion)
 (comment
  (f-evaluate '(labels ((quad (x) (square (square x)))
-                        (square (x) (* x x)))
-                       (quad 2))
-              {}
-              fenv-global)
- ;; => this unfortunately throws:
+                       (square (x) (* x x)))
+                      (quad 2))
+             {}
+             fenv-global)
+  ;; => this unfortunately throws:
  ;; clojure.lang.ExceptionInfo: Not a function {:expression ch02-lisp2/void, :extra-info ({:args (2)})}
  ;; - this is because `square` function called inside `quad` is resolved to void.
+
 
         .)


### PR DESCRIPTION
This shows a more complete version of `f-evaluate` as they demonstrate on pages 41-42.
It uses `f-lookup` instead of simple `lookup` to make sure function terms 
and values passed to `function` (new special form) are looked up in the functional environment,
not the regular one.


## flet, labels

It also shows implementation for `labels` which is a new special form similar to `flet`
but should allow cross-references between local functions.
However, the book doesn't talk about `labels` at all until the page 57 (Recursion).

The difference between `flet` and `labels` can be demonstrated on this example: 

### flet

```
(comment
 (f-evaluate '(flet ((square (x) (* x x))
                      (quad (x) (square (square x))))
                     ((lambda (x) (quad (quad x)))
                      2))
              {}
              fenv-global)
         .)
;; 1. Unhandled clojure.lang.ExceptionInfo
;; No such binding
;; {:expression square, :extra-info nil}
```

### labels

```
;; What previously failed, now returns the proper result
;; (2^4)^4 = 2^16 = 65536
(assert (= 65536
           (f-evaluate '(labels ((square (x) (* x x))
                                 (quad (x) (square (square x))))
                                ((lambda (x) (quad (quad x)))
                                 2))
                       {}
                       fenv-global)))
```

### TODO: but labels still fail if the references are not in order of the functions definitions

Question: is this something that works in the book's implementation?

UPDATE: yes, it works in the book because their env mappings are mutable

```
;; But if we flip the function definitions (quad is now first and it uses square defined later)
;; it's broken again!
;; Note: this works with the implementation from the book
;; because they are mutating the mapping in the env
;; With immutable environment, it's gonna be harder => let's deal with this in section 2.6 (Recursion)
(comment
 (f-evaluate '(labels ((quad (x) (square (square x)))
                        (square (x) (* x x)))
                       (quad 2))
              {}
              fenv-global)
 ;; => this unfortunately throws:
 ;; clojure.lang.ExceptionInfo: Not a function {:expression ch02-lisp2/void, :extra-info ({:args (2)})}
 ;; - this is because `square` function called inside `quad` is resolved to void.

```