### PR TITLE
2.6 (local) recursion - `let` and `letrec`

### DIFF
--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -1,1 +1,2 @@
-{:deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
+{:deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :aliases {:dev {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]}}}

--- a/clojure/src/ch02_lisp2.clj
+++ b/clojure/src/ch02_lisp2.clj
@@ -1007,7 +1007,7 @@ test-env
 
 ;; - now try to bind y with bind-de instead
 (dd-evaluate
- '(bind-de 'y 100
+ '(bind-de 'y 100 100
            (lambda ()
                    (* x (assoc-de 'y error))))
  (assoc e/env-global

--- a/clojure/src/ch02_recursion.clj
+++ b/clojure/src/ch02_recursion.clj
@@ -1,0 +1,67 @@
+(ns ch02-recursion
+  "Section 2.6 is all about recursion.
+  It's only loosly related to previous code that deals with Lisp2 characteristics
+  and dynamic variables.
+  That is why we create a separate namespace for Recursion."
+  (:require [ch01-evaluator-final :as e]))
+
+
+;; a canonical example of recursive function
+(defn fact [n]
+  (if (zero? n)
+    1
+    (* n (fact (dec n)))))
+
+(fact 5)
+;; => 120
+(fact 20)
+;; => 2432902008176640000
+
+;; Note: Clojure does not implement tail-call optimization (TCO)
+;; In this case, the fact isn't tail-recursive anyway
+;; and it also doesn't matter for anything but a very large results
+
+
+;; large numbers
+(comment
+  ;; ... much earlier we hit the max range of longs supported by `*`
+  (fact 21)
+  ;; 1. Unhandled java.lang.ArithmeticException
+  ;; long overflow
+
+  ;; ... we can use bigintegers
+  (fact 100N)
+  ;; => 93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000N
+
+  ;; ... or we have to use `'*`
+  (defn fact' [n]
+    (if (zero? n)
+      1
+      (*' n (fact' (dec n)))))
+  (fact' 100)
+  ;; => 93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000N
+
+ .)
+
+
+
+;;; 2.6.2 - Mutual recursion example (p. 56)
+
+;; First, forward declaration is needed to be able to use `my-odd?` inside `my-even?`
+(declare my-odd?)
+
+(defn my-even? [n]
+  (or (zero? n)
+      (my-odd? (dec n))))
+
+(defn my-odd? [n]
+  (if (zero? n)
+    false
+    (my-even? (dec n))))
+
+(my-even? 10)
+;; => true
+(my-even? 9)
+;; => false
+(my-odd? 9)
+;; => true

--- a/clojure/src/ch02_recursion.clj
+++ b/clojure/src/ch02_recursion.clj
@@ -65,3 +65,176 @@
 ;; => false
 (my-odd? 9)
 ;; => true
+
+
+
+;;; 2.6.3 Local Recursion in Lisp2
+;;; here they discuss `flet` and how it cannot be used to define recursive functions
+;;; Check Common Lisp docs:
+;;; - flet: https://jtra.cz/stuff/lisp/sclr/flet.html
+;;; - labels: https://jtra.cz/stuff/lisp/sclr/labels.html
+;;;
+;;; This is only used as a demonstration - it's not valid Clojure
+;;; and it might not even be a valid Common Lisp.
+(comment
+
+  ;; flet bindings aren't recursive and thus the `fact` function used in `flet`'s body
+  ;; is referring to the global `fact` function not the local function being defined
+  ;; => we get _no_ recursion as a result (if the global fact function isn't recursive)
+  ;; Note: this is Common Lisp - not Clojure!
+  (flet ((fact (n) (if (= n 0) 1
+                       (* n (fact (- n 1))))))
+        (fact 6))
+
+  ;; Therefore, in Lisp 1.5 they had `label` - this returns an anonymous function
+  ;; - however, it's not able to handle _mutual_ recursion
+  (label fact (lambda (n) (if (= n 0) 1
+                              (* n (fact (- n 1))))))
+  
+  ;; For (mutual) recursion, Common Lisp has `labels`:
+  (labels ((fact (n) (if (= n 0) 1
+                         (* n (fact (- n 1))))))
+          (fact 6))
+  ;; #t and #f must be commented otherwise the Clojure reader fails
+  (funcall (labels ((even? (n) (if (= n 0)
+                                 ;#t
+                                 (odd? (- n 1))))
+                    (odd? (n) (if (= n 0)
+                                ;#f
+                                (even? (- n 1)))))
+                   (function even?))
+           4)
+
+  .)
+
+
+;;; 2.6.4 Local Recursion in Lisp1
+
+;; p. 58 - try to reproduce letrec with simple let and using 'void
+;; - the very first, simplest attempt is doomed to fail because we cannot reference
+;;   undefined symbols in a let variable's value
+(comment 
+  (let [local-even? (fn [n] (or (zero? n) (local-odd? (dec n))))
+        local-odd? (fn [n] (if (zero? n) false (local-even? (dec n))))]
+    (local-even? 4))
+  ;;    Unable to resolve symbol: local-odd? in this context
+
+  .)
+
+;; - let's try to bind them to `void first and then redefine
+(let [local-even? `void
+      local-odd? `void
+      local-even? (fn [n] (or (zero? n) (local-odd? (dec n))))
+      local-odd? (fn [n] (if (zero? n) false (local-even? (dec n))))]
+  (local-even? 4))
+;; => nil
+;; as we see that didn't work because it returns nil because we didn't really redefined them in a good way
+;; - in Clojure, we cannot use `set!` to modify local bindings
+
+;; - let's try again with thread-local vars (see Joy of Clojure, p.258)
+;;   Surprisingly, this works without any extra effort!
+;;   `with-local-vars` is kinda special - check it's source code!
+;;   - it takes the names and binds each name to a Var object via `let`
+;;     these Var objects are unnamed and are only initialized in the let's body
+;;     so they can even refer to each other
+(with-local-vars
+ [local-even? (fn [n] (or (zero? n) (local-odd? (dec n))))
+  local-odd? (fn [n] (or (= n 1) (local-even? (dec n))))]
+  (local-even? 4))
+;; => true
+
+
+
+;;; 2.6.5 Creating Unitialized Bindings (p.60)
+;;; This shows a couple of attempts define uninitialized vars
+;;; without a special form and then uses a new special form `let`
+;;; Without a special form, we cannot avoid checks to avoid programmers
+;;; to use our special unitialized marker.
+
+
+;; Implement `let` as a special form -> add it to our interpreter
+;; This version supports the following form `(let ( variable ...))`
+;; where the variables can be just symbols in which case they are uninitialized
+
+(def ^:private the-uninitialized-marker `non-initialized)
+
+;; enhance `lookup` to make sure we fail fast when somebody tries to use an uninitialized value
+(defn lookup [id env]
+  (if-let [[_k v] (find env id)]
+    (if (= v the-uninitialized-marker)
+      (e/wrong "Uninitialized binding" id {:env env})
+      v)
+    (e/wrong "No such binding" id)))
+
+;; need to also redefine `eprogn` if we want to support nested `let`s in our language
+(declare evaluate)
+(defn eprogn
+  "Evaluates sequence of expressions in given environment."
+  [exps env]
+  (if (list? exps)
+    (let [[fst & rst] exps
+          ;; first expression is always evaluated
+          fst-val (evaluate fst env)]
+      (if (list? rst)
+        (eprogn rst env) ; process the rest of the forms by calling `eprogn` recursively
+        ;; the final term in the sequence
+        fst-val))
+    ;; here we could also return `nil` or other value - see discussion on p.10
+    ()))
+
+(defn evaluate [exp env]
+  (if (e/atom? exp)
+    (cond
+      ;; lock immutability of t and f in the interpreter
+      (= 't exp) true
+      (= 'f exp) false
+      (symbol? exp) (lookup exp env)
+      ;; Notice that `keyword?` isn't here because keywords are Clojure's thing
+      ;; and aren't present in the Lisp we are trying to implement
+      ((some-fn number? string? char? boolean? vector?) exp) exp
+      :else (e/wrong "Cannot evaluate - unknown atomic expression?" exp))
+
+    ;; we use `first` instead of `car`
+    (case (first exp)
+      quote (second exp)
+      ;; (p.8) we gloss over the fact that in `(if pred)` we use boolean semantics
+      ;; of the implementation language (Clojure - which means `nil` will be falsy);
+      ;; more precisely, we should write `(if-not (= the-false-value (evaluate (second exp) env)))
+      if (if (evaluate (second exp) env)
+           (evaluate (nth exp 2) env)
+           (evaluate (nth exp 3) env))
+      begin (eprogn (rest exp) env)
+      set! (e/update! (second exp) env (evaluate (nth exp 2) env))
+      lambda (e/make-function (second exp) (nnext exp) env)
+      ;; CHANGE: implement a new special form `let` including the support for uninitialized bindings
+      let (let [body (nnext exp)
+                bindings (second exp)
+                variables (map (fn [binding] (if (symbol? binding) binding (first binding)))
+                               bindings)
+                values (map (fn [binding] (if (symbol? binding)
+                                            the-uninitialized-marker
+                                            (evaluate (second binding) env)))
+                            bindings)]
+            (eprogn body (e/extend env variables values)))
+
+;; it's not a special form, just ordinary function => call it!
+      (e/invoke (evaluate (first exp) env)
+                (e/evlis (rest exp) env)))))
+
+;; firs try if it can create uninitialized bindings
+(evaluate '(let (local-even? local-odd?)
+             local-even?)
+          {})
+;; => ch02-recursion/non-initialized
+
+;; Can we now define even? and odd?
+(evaluate '(let (local-even? local-odd?)
+             (let ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
+                   (local-odd? (lambda (n) (if (= n 1) 'f (local-even? (- n 1))))))
+               (local-even? 4)))
+          (assoc e/env-global '= =))
+;; => t
+
+
+;; To avoid using nested lets it would be nice if we implemented `letrec` (p. 62)
+;; - for that we need to add it to our interpreter again

--- a/clojure/src/ch02_recursion.clj
+++ b/clojure/src/ch02_recursion.clj
@@ -321,7 +321,7 @@
                    new-env (e/extend env variables (mapv (constantly the-uninitialized-marker) bindings))
                    ;; then update variables to their proper values
                    values (mapv (fn [[_fn-name fn-def :as _binding]]
-                                  (e/evaluate fn-def new-env))
+                                  (evaluate fn-def new-env))
                                 bindings)
                    updated-env (e/extend env variables values)]
                (eprogn body updated-env))

--- a/clojure/src/ch02_recursion_with_mutable_env.clj
+++ b/clojure/src/ch02_recursion_with_mutable_env.clj
@@ -1,0 +1,242 @@
+(ns ch02-recursion-with-mutable-env
+  "This is a modification of `ch02-recursion` with a twist - we are using _mutable_ environment
+  to work around problems with `let` / `letrec` and immutable environments.
+  In particular, mutually recursive functions did not work (see `local-even?` and `local-odd?` example)
+  because anonymous functions created in `e/make-function` (used for 'lambda forms)
+  close over the environment passed to `make-function` - that is they use the (lexical) environment
+  as it was at the time the function was defined, not at the time it's being called.
+
+  In this version, we introduce a mutable version of our environment backed by an atom.
+  The relevant functions like `lookup` and `extend` have to be modified because
+  they rely on env's structure (assume that it's a hashmap).
+  We also need to modify `evaluate`, in particular how `let` and `letrec` are interpreted;
+  these special forms wraps immutable env (a hashmap) in a mutable reference (atom)
+  and pass it further to make sure the bindings' values and bodies are evaluated
+  using this mutable env."
+  (:require [ch01-evaluator-final :as e]))
+
+
+;;; 2.6.5 Creating Unitialized Bindings (p.60)
+;;; This shows a couple of attempts define uninitialized vars
+;;; without a special form and then uses a new special form `let`
+;;; Without a special form, we cannot avoid checks to avoid programmers
+;;; to use our special unitialized marker.
+
+
+;; Implement `let` as a special form -> add it to our interpreter
+;; This version supports the following form `(let ( variable ...))`
+;; where the variables can be just symbols in which case they are uninitialized
+
+(def ^:private the-uninitialized-marker `non-initialized)
+
+;; enhance `lookup` to make sure we fail fast when somebody tries to use an uninitialized value
+(defn lookup [id env]
+  (if-let [[_k v] (find env id)]
+    (if (= v the-uninitialized-marker)
+      (e/wrong "Uninitialized binding" id {:env env})
+      v)
+    (e/wrong "No such binding" id)))
+
+;; need to also redefine `eprogn` if we want to support nested `let`s in our language
+(declare evaluate)
+(defn eprogn
+  "Evaluates sequence of expressions in given environment."
+  [exps env]
+  (if (list? exps)
+    (let [[fst & rst] exps
+          ;; first expression is always evaluated
+          fst-val (evaluate fst env)]
+      (if (list? rst)
+        (eprogn rst env) ; process the rest of the forms by calling `eprogn` recursively
+        ;; the final term in the sequence
+        fst-val))
+    ;; here we could also return `nil` or other value - see discussion on p.10
+    ()))
+
+;; ... evlis must use the new evaluate too
+(defn evlis [exps env]
+  (if (list? exps)
+    (map #(evaluate % env) exps)
+    ()))
+
+
+;;; MUTABLE ENVIRONMENT
+;;; -------------------
+;;; To fix the problem mentioned above,
+;;; let's introduce a mutable environment (see also the ns docstring)
+;;; ------------------------------------------------------------------
+
+;; To be able to mutate it, we must use an _identity_ instead of a simple value
+;; Clojure has several "identities" (reference types), including
+;; - vars
+;; - atoms
+;; - refs
+;; - agents
+;; refs and agents are not useful for us at all
+;; we want atoms or vars and since environment is a "local value" passed around as a parameter,
+;; we don't really need a var (although we could use `with-local-vars` but that looks more complicated)
+;; => use an atom
+
+;; This atom, will be created _when_ we need it, that is inside `evaluate`,
+;; when interpreting `let` or `letrec`.
+;; We'll simply introduce `*mutable-env?*` variable - when set to true,
+;; the ananonymous function created by `make-function` can assume `env` is an atom,
+;; and will have to dereference it.
+
+;; don't use this because we don't need it!
+;; (def ^:dynamic *mutable-env?* false)
+
+;; once more, we need to modify `lookup` to check if the env is mutable or not
+(defn- mutable-env? [env]
+  (instance? clojure.lang.Atom env))
+
+(defn- mutable-env [env]
+  (if (instance? clojure.lang.Atom env)
+    env
+    (atom env)))
+
+(defn lookup [id env]
+  (if-let [[_k v] (find (cond-> env (mutable-env? env) deref) id)]
+    (if (= v the-uninitialized-marker)
+      (e/wrong "Uninitialized binding" id {:env env})
+      v)
+    (e/wrong "No such binding" id)))
+
+;; ... and we also need to modify `extend` which is the other operation working
+;; with the envrionment structure directly
+(defn extend [env variables values]
+  ;; we do not yet support special variables like `& args` capturing all the remaining values
+  (let [mutable? (mutable-env? env)
+        env-val (cond-> env mutable? deref)
+        updated-env (if (= (count variables) (count values))
+                      (into env-val (zipmap variables values))
+                      (e/wrong "The number of variables does not match the number of values"
+                               {:var-count (count variables) :val-count (count values)}
+                               {:env env-val :variables variables :values values}))]
+    (if mutable?
+      (reset! env updated-env) ; mutate the environment!
+      updated-env)))
+
+;; ... also need to update  `make-function` because it uses `extend`
+(defn make-function [variables body env]
+  (fn [values]
+    ;; use `env`, not `env-global` here:
+    (eprogn body (extend env variables values))))
+
+
+;; ... and maybe also `update!`
+
+
+(defn evaluate [exp env]
+  (if (e/atom? exp)
+    (cond
+      ;; lock immutability of t and f in the interpreter
+      (= 't exp) true
+      (= 'f exp) false
+      (symbol? exp) (lookup exp env)
+      ;; Notice that `keyword?` isn't here because keywords are Clojure's thing
+      ;; and aren't present in the Lisp we are trying to implement
+      ((some-fn number? string? char? boolean? vector?) exp) exp
+      :else (e/wrong "Cannot evaluate - unknown atomic expression?" exp))
+
+    ;; we use `first` instead of `car`
+    (case (first exp)
+      quote (second exp)
+      ;; (p.8) we gloss over the fact that in `(if pred)` we use boolean semantics
+      ;; of the implementation language (Clojure - which means `nil` will be falsy);
+      ;; more precisely, we should write `(if-not (= the-false-value (evaluate (second exp) env)))
+      if (if (evaluate (second exp) env)
+           (evaluate (nth exp 2) env)
+           (evaluate (nth exp 3) env))
+      begin (eprogn (rest exp) env)
+      set! (e/update! (second exp) env (evaluate (nth exp 2) env))
+      ;; CHANGE: using our new `make-function` implementation
+      lambda (make-function (second exp) (nnext exp) env)
+      ;; CHANGEs: let and letrec will bind `*mutable-env?*` to true
+      let (let [body (nnext exp)
+                bindings (second exp)
+                variables (mapv (fn [binding] (if (symbol? binding) binding (first binding)))
+                                bindings)
+                ;; CHANGE: use mutable env to allow redefinition of formerly unitialized variables
+                mut-env (mutable-env env)
+                values (mapv (fn [binding] (if (symbol? binding)
+                                             the-uninitialized-marker
+                                             (evaluate (second binding) mut-env)))
+                             bindings)]
+            ;; CHANGE: use custom `extend`
+            (eprogn body (extend mut-env variables values)))
+      ;; CHANGE: let's implement letrec!
+      letrec (let [body (nnext exp)
+                   bindings (second exp)
+                   ;; first add variables with uninitialized values
+                   variables (mapv first bindings)
+                   ;; CHANGE: use custome `extend`
+                   new-env (extend env variables (mapv (constantly the-uninitialized-marker) bindings))
+                   ;; CHANGE: use mutable env to allow redefinition of formerly unitialized variables
+                   mut-env (mutable-env new-env)
+                   ;; then update variables to their proper values
+                   values (mapv (fn [[_fn-name fn-def :as _binding]]
+                                  (evaluate fn-def mut-env))
+                                bindings)]
+               ;; CHANGE: use custom `extend`
+               (eprogn body (extend mut-env variables values)))
+
+      ;; it's not a special form, just ordinary function => call it!
+      (e/invoke (evaluate (first exp) env)
+                ;; CHANGE: use own `evlis`
+                (evlis (rest exp) env)))))
+
+;; define minimal enviroinment used to invoke our interpreter
+;; to avoid problems with `e/global-env`, in particular when using `letrec`
+;; (because it would eventually use the old functions from `ch01-evaluator-final` ns)
+(def minimal-env
+  {'= #(apply = %)
+   '- #(apply - %)
+   '+ #(apply + %)
+   'list #(apply list %)})
+
+;; Now try our example again
+(evaluate '(let (local-even? local-odd?)
+             (let ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
+                   (local-odd? (lambda (n) (if (= n 0) 'f (local-even? (- n 1))))))
+               (local-even? 4)))
+          minimal-env)
+;; YES!
+;; => t
+
+
+;; more complex `let` example:
+(assert
+ (= '(t f f t)
+    (evaluate '(let (local-even? local-odd?)
+                 (let ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
+                       (local-odd? (lambda (n) (if (= n 0) 'f (local-even? (- n 1))))))
+                   (list (local-even? 4)
+                         (local-odd? 4)
+                         (local-even? 5)
+                         (local-odd? 5))))
+              minimal-env)))
+
+;; And some `letrec` to get rid of the nested let-s (p. 62)
+(assert
+ (= '(t t)
+    (evaluate '(letrec ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
+                        (local-odd? (lambda (n) (if (= n 0) 'f (local-even? (- n 1))))))
+                       (list (local-even? 6)
+                             (local-odd? 7)))
+              minimal-env)))
+
+(assert
+ (= '(t f f t)
+    (evaluate '(letrec ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
+                        (local-odd? (lambda (n) (if (= n 0) 'f (local-even? (- n 1))))))
+                       (let ((x (+ 2 3)))
+                         (list (local-even? 4)
+                               (local-odd? (+ 2 2))
+                               (local-even? x)
+                               (local-odd? x))))
+              minimal-env)))
+;; => t
+
+
+


### PR DESCRIPTION
The whole section is about recursion and we mostly focus on local recursion as discussed in section 2.6.4 _Local Recursion in Lisp1 _ and later.

We implement `let` with support for uninitialized variables
and later `letrec` (similar to Clojure's `letfn`) that allows us to define mutually recursive functions easily.

## Mutual recursion problem - `let` and `letrec`

This doesn't work yet - see the problem description here: https://github.com/jumarko/lisp-in-small-pieces/pull/26/files#diff-6d926e349519bf1342148f4011864de539902ff20642ca0a6f7b6d91ff621e48R244-R265

```
(evaluate '(let (local-even? local-odd?)
             (let ((local-even? (lambda (n) (if (= n 0) 't (local-odd? (- n 1)))))
                   (local-odd? (lambda (n) (if (= n 0) 'f (local-even? (- n 1))))))
               (local-even? 4)))
          e/env-global)

;;=> 
1. Unhandled clojure.lang.ExceptionInfo
   Not a function
   {:expression ch02-recursion/non-initialized, :extra-info ({:args (3)})}
  ch01_evaluator_final.clj:   30  ch01-evaluator-final/wrong
  ch01_evaluator_final.clj:   29  ch01-evaluator-final/wrong
               RestFn.java:  442  clojure.lang.RestFn/invoke
  ch01_evaluator_final.clj:   63  ch01-evaluator-final/invoke
  ch01_evaluator_final.clj:   60  ch01-evaluator-final/invoke
  ch01_evaluator_final.clj:  147  ch01-evaluator-final/evaluate

```

I already had this problem before when I tried to implement `labels` in section 2.4 (p. 42): see https://github.com/jumarko/lisp-in-small-pieces/blob/develop/clojure/src/ch02_lisp2.clj#L470-L486


### Experiment with mutable environment

See `ch02-recursion-with-mutable-env` ns: 


  This is a modification of `ch02-recursion` with a twist - we are using _mutable_ environment
  to work around problems with `let` / `letrec` and immutable environments.
  In particular, mutually recursive functions did not work (see `local-even?` and `local-odd?` example)
  because anonymous functions created in `e/make-function` (used for 'lambda forms)
  close over the environment passed to `make-function` - that is they use the (lexical) environment
  as it was at the time the function was defined, not at the time it's being called.

  In this version, we introduce a mutable version of our environment backed by an atom.
  The relevant functions like `lookup` and `extend` have to be modified because
  they rely on env's structure (assume that it's a hashmap).
  We also need to modify `evaluate`, in particular how `let` and `letrec` are interpreted;
  these special forms wraps immutable env (a hashmap) in a mutable reference (atom)
  and pass it further to make sure the bindings' values and bodies are evaluated
  using this mutable env.